### PR TITLE
Fixing No Affiliation bug on attestorOrganisation ID

### DIFF
--- a/src/controllers/utils/modelHelper.ts
+++ b/src/controllers/utils/modelHelper.ts
@@ -219,7 +219,7 @@ export const getOrCreateAttestorOrganisation = async (
   const timestamp = attestTimestamp || new Date();
 
   // Generate unique key
-  const key = `NO_AFFILIATION${attestor.id}`;
+  const key = `${ZERO_UID}${attestor.id}`;
 
   const newAttestorOrganisation = new AttestorOrganisation({
     id: key,


### PR DESCRIPTION
Fixes this issue at editing vouch from no affiliated user

![image](https://github.com/user-attachments/assets/656836fd-06d2-4655-8bea-01e1d5918a3d)

Here's how attestorOrganisations ID are being saved 

![image](https://github.com/user-attachments/assets/d5932484-c92b-48f8-9019-c7fa29fc2884)

EAS is expecting a hex value, I propose to add ZERO_UID before unless you guys propose something else


