### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/Giveth/DeVouch-BE?style=flat&labelColor=black&color=%23F35D23)
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Giveth/DeVouch-BE)
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/Giveth/DeVouch-BE)
 
 # Introduction
 


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "Open in Codeanywhere" badge to the README, providing a quick link for developers to launch the project environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->